### PR TITLE
Add NAS platform libraries to platform specific metapackages

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.9.3
 
 # Package: opx-platform-config-dell-s6000-vm
 # Architecture: any
-# Depends: ${shlibs:Depends}, ${misc:Depends}, libopx-sdi-sys-vm1, libopx-sai-vm1
+# Depends: ${shlibs:Depends}, ${misc:Depends}, libopx-sdi-sys-vm1, libopx-sai-vm1, libopx-nas-platform-vm1
 # Description: Platform specific files and packages for VM simulation of Dell Networking S6000-ON
 
 # Package: opx-dell-s6000-vm
@@ -17,7 +17,7 @@ Standards-Version: 3.9.3
 
 Package: opx-platform-config-dell-s6000
 Architecture: any
-Depends: opx-dell-s6000-modules, i2c-tools, dmidecode, libopx-sdi-device-drivers1, libopx-sdi-sys1
+Depends: opx-dell-s6000-modules, i2c-tools, dmidecode, libopx-sdi-device-drivers1, libopx-sdi-sys1, libopx-nas-platform-s6000-1
 Description: Package to install on a Dell Networking S6000-ON
 
 Package: opx-dell-s6000


### PR DESCRIPTION
Change adds libopx-nas-platform-vm1 to VM metapackage
Change adds libopx-nas-platform-s6000-1 to S6000 metapackage