### PR TITLE
Mount ONIE-BOOT partition on /mnt/onie-boot

### DIFF
--- a/common/etc/fstab
+++ b/common/etc/fstab
@@ -1,0 +1,3 @@
+# Default fstab for OPX
+# ONIE partition
+PARTLABEL=ONIE-BOOT /mnt/onie-boot auto defaults,rw


### PR DESCRIPTION
This allows the system to automatically mount the ONIE-BOOT partition in accordance with the ONIE spec