### PR TITLE
feat: logrotate enhancements

### DIFF
--- a/common/etc/logrotate.conf
+++ b/common/etc/logrotate.conf
@@ -5,6 +5,9 @@ daily
 # keep 4 weeks worth of backlogs
 rotate 7
 
+# max size
+maxsize 1M 
+
 # copytruncate 
 copytruncate
 
@@ -17,6 +20,7 @@ include /etc/logrotate.d
 # no packages own wtmp, or btmp -- we'll rotate them here
 /var/log/wtmp {
     missingok
+    maxsize 1M 
     daily
     copytruncate
     compress
@@ -26,6 +30,7 @@ include /etc/logrotate.d
 
 /var/log/btmp {
     missingok
+    maxsize 1M 
     daily
     copytruncate
     compress

--- a/common/etc/logrotate.d/redis-server
+++ b/common/etc/logrotate.d/redis-server
@@ -1,4 +1,5 @@
 /var/log/redis/redis-server*.log {
+        maxsize 1M 
         daily
         missingok
         rotate 7 

--- a/common/etc/logrotate.d/rsyslog
+++ b/common/etc/logrotate.d/rsyslog
@@ -1,7 +1,7 @@
 /var/log/syslog
 {
 	rotate 7
-        maxsize 1M 
+	maxsize 1M 
 	daily
 	missingok
 	notifempty
@@ -26,7 +26,7 @@
 /var/log/messages
 {
 	rotate 7
-        maxsize 1M 
+	maxsize 1M 
 	daily
 	missingok
 	notifempty

--- a/common/etc/logrotate.d/rsyslog
+++ b/common/etc/logrotate.d/rsyslog
@@ -1,6 +1,7 @@
 /var/log/syslog
 {
 	rotate 7
+        maxsize 1M 
 	daily
 	missingok
 	notifempty
@@ -25,6 +26,7 @@
 /var/log/messages
 {
 	rotate 7
+        maxsize 1M 
 	daily
 	missingok
 	notifempty

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+opx-platform-config (1.5.2+opx1) unstable; urgency=medium
+
+  * feat: logrotate configuration enhancements 
+
+ -- Dell EMC <opx-dev@lists.openswitch.net>  Tue, 13 Sep 2018 16:00:00 -0800
+
 opx-platform-config (1.5.2) unstable; urgency=medium
 
   * Bugfix: Mismatched tag in nas_detail_list.xml for z9264f platform


### PR DESCRIPTION
Log files to be rotated after 1M, even if it is earlier than 24 hrs
since last rotation.

Signed-off-by: Nalini Chervela <nalini_chervela@dell.com>