### PR TITLE
fix: Remove opx-udrvr-ethernet from s5248f dependency.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -163,7 +163,7 @@ Description: All packages for Dell Networking S5148F-ON
 Package: opx-platform-config-dell-s5248f
 Architecture: all
 Replaces: opx-nas-acl, logrotate, rsyslog, redis-server
-Depends: opx-dell-modules, i2c-tools, dmidecode, libopx-sdi-sys1 (>= 1.5.1+opx3), opx-udrvr-ethernet
+Depends: opx-dell-modules, i2c-tools, dmidecode, libopx-sdi-sys1 (>= 1.5.1+opx3)
 Description: Platform-specific files and packages for Dell Networking S5248F-ON
 
 Package: opx-dell-s5248f


### PR DESCRIPTION
igb compatible with new platforms so no need to remove it

Signed-off-by: Tejaswi Goel <Tejaswi_Goel@Dell.com>